### PR TITLE
Fix: Disable cache-busting timestamp to resolve 403 on shared hosting, fixes #18

### DIFF
--- a/src/FetchMeditation/Utilities/HttpUtility.php
+++ b/src/FetchMeditation/Utilities/HttpUtility.php
@@ -14,7 +14,7 @@ class HttpUtility
         'timeout' => 30
     ];
 
-    public static function httpGet(string $url, array $params = [], bool $cacheBusting = true): string
+    public static function httpGet(string $url, array $params = [], bool $cacheBusting = false): string
     {
         if ($cacheBusting) {
             $params['t'] = time();

--- a/src/FetchMeditation/Utilities/HttpUtility.php
+++ b/src/FetchMeditation/Utilities/HttpUtility.php
@@ -14,12 +14,8 @@ class HttpUtility
         'timeout' => 30
     ];
 
-    public static function httpGet(string $url, array $params = [], bool $cacheBusting = false): string
+    public static function httpGet(string $url, array $params = []): string
     {
-        if ($cacheBusting) {
-            $params['t'] = time();
-        }
-
         if (!empty($params)) {
             $url = self::appendQueryParams($url, $params);
         }


### PR DESCRIPTION
## Related Issue
 
Closes #18
 
## Change
 
In `src/FetchMeditation/Utilities/HttpUtility.php`, remove the `$cacheBusting` parameter and the associated timestamp logic from `httpGet` entirely:
 
```php
// Before
public static function httpGet(string $url, array $params = [], bool $cacheBusting = true): string
{
    if ($cacheBusting) {
        $params['t'] = time();
    }
    ...
}
 
// After
public static function httpGet(string $url, array $params = []): string
{
    ...
}
```
 
No callers were passing `$cacheBusting` explicitly, so there is no API impact.
 
## Why
 
The cache-busting timestamp (`?t=NNNN`) appended to all requests triggers Cloudflare's bot detection on shared hosting IP ranges (confirmed on HostGator), causing all JFT and SPAD fetches to return 403.
 
Investigation also confirmed the timestamp was ineffective — MD5 comparison of response bodies with and without the parameter returned identical hashes, confirming WP Engine ignores query parameters for cache invalidation. After consultation with @pjaudiomv we agreed to just remove this parameter.
 
## Testing
 
All existing tests pass without modification. The existing test suite was reviewed:
 
- `HttpUtilityTest.php` tests `appendQueryParams` only and is unaffected
- `EnglishJFTTest.php` and `EnglishSPADTest.php` use mock subclasses that bypass `HttpUtility` entirely and are unaffected
- `JFTTest.php` and `SPADTest.php` make live network requests and continue to pass
 
Additionally verified end-to-end by running the plugin's fetch library directly from an affected HostGator server before and after the change:
 
| | Before | After |
|---|---|---|
| JFT fetch() | ❌ 403 | ✅ 200 |
| SPAD fetch() | ❌ 403 | ✅ 200 |